### PR TITLE
Point to Debian package in README's ##installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Read simulator for nanopore DRS datasets.
 
 `pip install git+git://github.com/bartongroup/yanosim`
 
+alternatively, your Linux distribution may offer yanosim directly. On Debian and Ubuntu systems try
+
+`sudo apt install yanosim`
+
 ## Usage:
 
 ### `model`:


### PR DESCRIPTION
Hello,

Yanosim was just [accepted](https://tracker.debian.org/pkg/yanosim} by Debian Linux as part of our perpetual [Covid-19 hackathon](https://salsa.debian.org/med-team/community/2020-covid19-hackathon). In about 5 days the package will automigrate to Debian testing and the current devel release of Ubuntu is also expected to pick it up.

I am not completely sure about how yanosim will help us. What I had in mind when I was suggesting the package was that it could help providing a ground truth for testing workflows, or by generating data quickly without shipping them as part of a package. Please kindly think along about how you think Debian as a Linux distribution can help to improve the overall nanopore experience.

With best regards and wishes

Steffen
